### PR TITLE
fix: remove sync call to cart

### DIFF
--- a/theme/components/async/mini-cart.html.twig
+++ b/theme/components/async/mini-cart.html.twig
@@ -244,7 +244,8 @@
 {% schema %}
 {
     "cart": {
-        "type": "array"
+        "type": "cart",
+        "optional": true
     }
 }
 {% endschema %}

--- a/theme/components/sections/header.html.twig
+++ b/theme/components/sections/header.html.twig
@@ -240,7 +240,7 @@
                     isDropdown: true,
                 } %}
                     {% block content %}
-                        {{ async('mini-cart', 'mini-cart', { props: { cart: cart() } }) }}
+                        {{ async('mini-cart', 'mini-cart', { props: { cart: [] } }) }}
                     {% endblock %}
                 {% endembed %}
             </div>


### PR DESCRIPTION
Removing sync call to `cart` so header template is cacheable