### PR TITLE
chore: update hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules/
 
 # dotenv environment variable files
 .env
+
+.DS_Store

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit ${1}

--- a/package.json
+++ b/package.json
@@ -24,11 +24,6 @@
         "*.js": "eslint --max-warnings=0",
         "*.css": "stylelint --max-warnings=0"
     },
-    "husky": {
-        "hooks": {
-            "pre-commit": "lint-staged"
-        }
-    },
     "volta": {
         "node": "20.11.0"
     }


### PR DESCRIPTION
### Changes

After updating `husky` to the latest version, we don't need any of these deprecated configs