### PR TITLE
refactor(home): update home sections

### DIFF
--- a/site/pages/home.json
+++ b/site/pages/home.json
@@ -1,5 +1,11 @@
 {
     "props": {
+        "banner": {
+            "props": {
+                "alt": "Home page banner",
+                "marquee": "Stay dry this spring"
+            }
+        },
         "main": [
             {
                 "props": {
@@ -52,13 +58,7 @@
                 },
                 "template": "home/featured-items"
             }
-        ],
-        "banner": {
-            "props": {
-                "alt": "Home page banner",
-                "marquee": "Stay dry this spring"
-            }
-        }
+        ]
     },
     "template": "templates/pages/home",
     "route": "/"

--- a/site/pages/home.json
+++ b/site/pages/home.json
@@ -3,13 +3,6 @@
         "main": [
             {
                 "props": {
-                    "alt": "Home page banner",
-                    "marquee": "Stay dry this spring"
-                },
-                "template": "home/banner"
-            },
-            {
-                "props": {
                     "heading": "Shop by category",
                     "categories": {
                         "pagination": {
@@ -59,7 +52,13 @@
                 },
                 "template": "home/featured-items"
             }
-        ]
+        ],
+        "banner": {
+            "props": {
+                "alt": "Home page banner",
+                "marquee": "Stay dry this spring"
+            }
+        }
     },
     "template": "templates/pages/home",
     "route": "/"

--- a/theme/templates/pages/home.html.twig
+++ b/theme/templates/pages/home.html.twig
@@ -10,7 +10,7 @@
 
 <div class="home-page">
     {{ section('home/banner', banner) }}
-    {{ section_container(main) }}
+    {{ section_container(main, 'Main sections') }}
 </div>
 
 

--- a/theme/templates/pages/home.html.twig
+++ b/theme/templates/pages/home.html.twig
@@ -9,6 +9,7 @@
 {{ register_asset('css/templates/pages/home.css') }}
 
 <div class="home-page">
+    {{ section('home/banner', banner) }}
     {{ section_container(main) }}
 </div>
 
@@ -17,6 +18,9 @@
 
 {% schema %}
 {
+    "banner": {
+        "type": "section"
+    },
     "main": {
         "type": "section-list"
     }


### PR DESCRIPTION
### Changes
* Move the banner props out of the `main` `section-list`
* Make the banner standalone and always at the top
* Add a label to `main` section container

#### Editor output
![image](https://github.com/square/brisk-theme/assets/879656/f55b935d-3acd-4b97-9b69-518aec61c88b)
