### PR TITLE
ci(github-actions): add commit linting

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -1,0 +1,13 @@
+name: Lint Commit Messages
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  commitlint:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -11,3 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: wagoid/commitlint-github-action@v5
+        helpURL: https://github.com/square/brisk-theme/blob/main/CONTRIBUTING.md

--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -1,4 +1,4 @@
-name: Lint Commit Messages
+name: Lint commits
 on:
   pull_request:
 permissions:


### PR DESCRIPTION
Commits are linted via `precommit` hook, match having this validate on the CI too for those who don't have the `precommit` hooks installed

