### PR TITLE
ci(github-action): use latest version of checkout action

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v5
         with:
           helpURL: "${{ github.server_url }}/${{ github.repository }}/blob/main/CONTRIBUTING.md"


### PR DESCRIPTION
Update `actions/checkout@v4`, v3 has some warnings and deprecations