### PR TITLE
refactor: replace search-results async with include

### DIFF
--- a/theme/assets/js/components/search.js
+++ b/theme/assets/js/components/search.js
@@ -2,6 +2,7 @@ document.addEventListener('alpine:init', () => {
     const createSearchData = () => ({
         model: '',
         items: [],
+        isSearching: false,
         suggestionApiConfig: {
             method: 'POST',
             headers: {
@@ -59,8 +60,22 @@ document.addEventListener('alpine:init', () => {
         },
         async refreshResults() {
             if (Square.async.templates?.['search-results']) {
-                const props = { items: this.items, query: this.model };
-                Square.async.refreshAsyncTemplate('search-results', props, { replaceContent: true });
+                this.isSearching = true;
+
+                const searchResults = document.querySelector('#searchResults');
+
+                if (searchResults) {
+                    await Utils.refreshTemplate({
+                        template: 'partials/components/search-results',
+                        props: {
+                            items: this.items,
+                            query: this.model,
+                        },
+                        el: searchResults,
+                    });
+                }
+
+                this.isSearching = false;
             }
         },
     });

--- a/theme/assets/js/helpers/utils.js
+++ b/theme/assets/js/helpers/utils.js
@@ -393,4 +393,57 @@ window.Utils = {
             }
         }
     },
+    /**
+     * Load nested scripts before rendering a template
+     * @param {Object} el
+     * @param {Object} content
+     */
+    async loadScriptsBeforeTemplateRender(el, content) {
+        // Temporarily wrap the content with <template> so Alpine doesn't initialize x-data attributes
+        // eslint-disable-next-line no-param-reassign
+        el.innerHTML = `<template>${content}<div id="async-template-wrapper"></div></template>`;
+        // Wait until the dialog content is ready
+        await Utils.waitUntil(() => el.querySelector('template')?.content);
+
+        // Finds all nested script tags
+        const templateContent = el.querySelector('template').content;
+        const scripts = templateContent.querySelectorAll('script');
+        const scriptPromises = [];
+
+        scripts.forEach((script) => {
+            if (script.src) {
+                scriptPromises.push(this.loadScript(script.src));
+            }
+        });
+
+        if (scriptPromises.length) {
+            // Load scripts
+            await Promise.all(scriptPromises);
+            // Initiate Alpine after all scripts are loaded
+            document.dispatchEvent(new CustomEvent('async:alpine:init'));
+        }
+    },
+    /**
+     * Fetch template and update dom element
+     * @param {Object} payload
+     * @param {String} payload.template
+     * @param {Object} payload.props
+     * @param {Object} payload.el
+     * @return {Promise}
+     */
+    async refreshTemplate({ template, props, el }) {
+        if (!template || !props || !el) {
+            return Promise.resolve();
+        }
+        return SquareWebSDK.template.getTemplate({
+            template,
+            props,
+        }).then(async (text) => {
+            await this.loadScriptsBeforeTemplateRender(el, text);
+
+            // Re-assign the content without the <template> tag
+            // eslint-disable-next-line no-param-reassign
+            el.innerHTML = text;
+        });
+    },
 };

--- a/theme/partials/components/search-results.html.twig
+++ b/theme/partials/components/search-results.html.twig
@@ -1,6 +1,3 @@
-{% async:content %}
-
-
 {# If no query is passed, we'll default to popular items #}
 {% if query is not defined %}
     {% set items = popular_items({ pagination: { page_size: 4 } }) %}
@@ -65,11 +62,12 @@
     </div>
 {% endif %}
 
-{% endasync %}
-
-{% async:loading %}
-{{ include('partials/ui/loader') }}
-{% endasync %}
+<div
+    id="searchResults"
+    class="ui-loader--overlay"
+>
+    {{ include('partials/ui/loader') }}
+</div>
 
 {% schema %}
 {

--- a/theme/templates/components/dialogs/search-content.html.twig
+++ b/theme/templates/components/dialogs/search-content.html.twig
@@ -33,5 +33,5 @@
     </div>
 
     {# search results here, it's async and will be refreshed #}
-    {{ async('search-results', 'search-results', { props: { items: [] } }) }}
+    {{ include('partials/components/search-results', { items: [] }) }}
 </div>


### PR DESCRIPTION
Another example of migrating one async template to include. Full migration example - https://github.com/square/brisk-theme/pull/50