### PR TITLE
fix: rename 'option' to 'control' in section controls

### DIFF
--- a/theme/components/sections/header.html.twig
+++ b/theme/components/sections/header.html.twig
@@ -321,21 +321,21 @@
     "name": "Header",
     "controls": [
         {
-            "option": "toggle",
+            "control": "toggle",
             "label": "Show announcement bar",
             "value": {
                 "$ref": "#/schema/announcement_bar_show"
             }
         },
         {
-            "option": "input",
+            "control": "input",
             "label": "Announcement bar",
             "value": {
                 "$ref": "#/schema/announcement_bar_text"
             }
         },
         {
-            "option": "link-chooser",
+            "control": "link-chooser",
             "label": "Announcement link",
             "value": {
                 "$ref": "#/schema/announcement_bar_link"

--- a/theme/components/sections/home/banner.html.twig
+++ b/theme/components/sections/home/banner.html.twig
@@ -40,18 +40,18 @@
     "name": "Banner",
     "controls": [
         {
-            "option": "group",
+            "control": "group",
             "label": "Banner image",
             "value": {
                 "controls": [
                     {
-                        "option": "image-chooser",
+                        "control": "image-chooser",
                         "value": {
                             "$ref": "#/schema/image"
                         }
                     },
                     {
-                        "option": "input",
+                        "control": "input",
                         "label": "Image description",
                         "placeholder": "Alt text for accessibility",
                         "value": {
@@ -62,7 +62,7 @@
             }
         },
         {
-            "option": "input",
+            "control": "input",
             "label": "Marquee text",
             "placeholder": "Scrolling text",
             "value": {

--- a/theme/components/sections/home/featured-categories.html.twig
+++ b/theme/components/sections/home/featured-categories.html.twig
@@ -28,19 +28,19 @@
     "name": "Featured categories",
     "controls": [
         {
-            "option": "input",
+            "control": "input",
             "label": "Heading",
             "value": {
                 "$ref": "#/schema/heading"
             }
         },
         {
-            "option": "group",
+            "control": "group",
             "label": "Featured categories",
             "value": {
                 "controls": [
                     {
-                        "option": "category-list-chooser",
+                        "control": "category-list-chooser",
                         "value": {
                             "$ref": "#/schema/categories"
                         }

--- a/theme/components/sections/home/featured-items.html.twig
+++ b/theme/components/sections/home/featured-items.html.twig
@@ -28,19 +28,19 @@
     "name": "Featured items",
     "controls": [
         {
-            "option": "input",
+            "control": "input",
             "label": "Heading",
             "value": {
                 "$ref": "#/schema/heading"
             }
         },
         {
-            "option": "group",
+            "control": "group",
             "label": "Items",
             "value": {
                 "controls": [
                     {
-                        "option": "item-list-chooser",
+                        "control": "item-list-chooser",
                         "value": {
                             "$ref": "#/schema/items"
                         }

--- a/theme/components/sections/home/text.html.twig
+++ b/theme/components/sections/home/text.html.twig
@@ -18,14 +18,14 @@
     "name": "Text",
     "controls": [
         {
-            "option": "input",
+            "control": "input",
             "label": "Heading",
             "value": {
                 "$ref": "#/schema/heading"
             }
         },
         {
-            "option": "textarea",
+            "control": "textarea",
             "label": "Text",
             "value": {
                 "$ref": "#/schema/text"


### PR DESCRIPTION
Refactors all section controls to use new `control` prop naming convection instead of `option` (`option` will remain supported for a transitional period).